### PR TITLE
Change wheel rotation direction in URDF

### DIFF
--- a/gopigo3_description/urdf/gopigo3.urdf.xacro
+++ b/gopigo3_description/urdf/gopigo3.urdf.xacro
@@ -79,7 +79,7 @@
     <!-- Ty is half the shaft lenght -->
     <!-- Tz = -(0.075 base_link cdg -0.033 wheel radius) = -0.042 -->
     <origin xyz="0 0.058 -0.042" rpy="0 0 1.57"/>
-    <axis xyz="-1 0 0"/>
+    <axis xyz="1 0 0"/>
   </joint>
 
   <link name="wheel_left_link">
@@ -120,7 +120,7 @@
     <child link="wheel_right_link"/>
     <origin xyz="0 -0.058 -0.042" rpy="0 0 -1.57"/>
     <!--axis xyz="0 0 1"/-->
-    <axis xyz="1 0 0"/>
+    <axis xyz="-1 0 0"/>
   </joint>
 
   <link name="wheel_right_link">


### PR DESCRIPTION
This is needed to go forward in response to a positive velocity command.
Without this modification the GoPiGo3 URDF model cannot be used with the Navigation Stack, when simulated in Gazebo (the robot would always move in the opposite direction as commanded).