### PR TITLE
Remove duplicated distance sensor controller from gopigo3.gazebo.xacro

### DIFF
--- a/gopigo3_description/urdf/gopigo3.gazebo.xacro
+++ b/gopigo3_description/urdf/gopigo3.gazebo.xacro
@@ -66,45 +66,6 @@
     </plugin>
   </gazebo>
 
-<!-- Distance Sensor controller -->
-  <gazebo reference="distance_sensor">        
-    <sensor type="ray" name="laser_distance">
-      <pose>0 0 0 0 0 0</pose>
-      <visualize>true</visualize>
-      <update_rate>10</update_rate>
-      <ray>
-         <scan>
-            <horizontal>
-               <samples>10</samples>
-               <resolution>1</resolution> 
-               <min_angle>-0.01</min_angle>
-               <max_angle>0.01</max_angle>
-            </horizontal>
-            <vertical>
-               <samples>10</samples>
-               <resolution>1</resolution> 
-               <min_angle>-0.01</min_angle>
-               <max_angle>0.01</max_angle> 
-            </vertical>
-         </scan>
-         <range>
-            <min>0.01</min>
-            <max>3</max>
-            <resolution>0.01</resolution>
-         </range>
-      </ray>
-      <plugin filename="libgazebo_ros_range.so" name="gazebo_ros_ir">
-         <gaussianNoise>0.005</gaussianNoise>
-         <alwaysOn>true</alwaysOn>
-         <updateRate>0.0</updateRate>
-         <topicName>gopigo/distance</topicName>
-         <frameName>distance_sensor</frameName>
-         <radiation>INFRARED</radiation>
-         <fov>0.02</fov>
-      </plugin>
-    </sensor>  
-   </gazebo>
-
 <!-- IMU sensor -->
   <gazebo reference="imu_link">
     <sensor type="imu" name="imu">


### PR DESCRIPTION
There were two copies of the same "distance_sensor" in gopigo3.gazebo.xacro. One of them had the <visualize> property set permanently to true. This prevented hiding the sensor in simulation even if "distance_visual" argument was set to false.